### PR TITLE
Fix IME submissions dropping leading digits

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1700,6 +1700,35 @@ mod tests {
     }
 
     #[test]
+    fn ascii_prefix_survives_non_ascii_followup() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE));
+        assert!(composer.is_in_paste_burst());
+
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('あ'), KeyModifiers::NONE));
+
+        let (result, _) =
+            composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        match result {
+            InputResult::Submitted(text) => assert_eq!(text, "1あ"),
+            _ => panic!("expected Submitted"),
+        }
+    }
+
+    #[test]
     fn handle_paste_small_inserts_text() {
         use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;

--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -198,12 +198,15 @@ impl PasteBurst {
 
     /// Before applying modified/non-char input: flush buffered burst immediately.
     pub fn flush_before_modified_input(&mut self) -> Option<String> {
-        if self.is_active() {
-            self.active = false;
-            Some(std::mem::take(&mut self.buffer))
-        } else {
-            None
+        if !self.is_active() {
+            return None;
         }
+        let mut out = std::mem::take(&mut self.buffer);
+        if let Some((ch, _)) = self.pending_first_char.take() {
+            out.push(ch);
+        }
+        self.clear_after_explicit_paste();
+        if out.is_empty() { None } else { Some(out) }
     }
 
     /// Clear only the timing window and any pending first-char.


### PR DESCRIPTION
## Summary
- ensure paste burst flush preserves ASCII characters before IME commits
- add regression test covering digit followed by Japanese text submission

Fixes #4356

## Testing
- just fmt
- just fix -p codex-tui
- cargo test -p codex-tui
